### PR TITLE
Added Sponsor details

### DIFF
--- a/_reactfoo_events/2017.md
+++ b/_reactfoo_events/2017.md
@@ -25,4 +25,12 @@ sponsor:
     size: "l"
     sponsors:
     - qube-cinema
+  - title: "Bronze Sponsor"
+    size: "m"
+    sponsors:
+    - thoughtworks
+  - title: "Community Sponsor"
+    size: "s"
+    sponsors:
+    - e2enetworks
 ---


### PR DESCRIPTION
Added the below sponsor details.
E2E as community sponsor and Thoughtworks as Bronze sponsor.



**Event title:**

**Organizer's name:**

cc @hasgeek/events-review
