### PR TITLE
Adding sponsor logos

### DIFF
--- a/_jsfoo_events/2017.md
+++ b/_jsfoo_events/2017.md
@@ -72,4 +72,19 @@ sponsor:
 
     For further information on sponsorship, please write to us at [info@hasgeek.com](mailto:info@hasgeek.com) or call us at [+91-767-633-2020](tel:+917676332020)
   sponsorship_deck_url: 'http://hsgk.in/DeveloperWeek2017-sponsor-kit'
+  sponsors:
+  - title: "Silver Sponsor"
+    size: "l"
+    sponsors:
+    - qube-cinema
+  - title: "Bronze Sponsor"
+    size: "m"
+    sponsors:
+    - equal-experts
+  - title: "Meetup Sponsor"
+    size: "m"
+    sponsors:
+    - walmartlabs
+    
+
 ---


### PR DESCRIPTION
Added Qube as Silver sposnor, Walmartlabs as Meetup sponsor and Equal experts as Bronze sponsor.



**Event title:**

**Organizer's name:**

cc @hasgeek/events-review
