### PR TITLE
Renamed WalmartLabs as Meetup & Hacknight Sponsor

### DIFF
--- a/_jsfoo_events/2017.md
+++ b/_jsfoo_events/2017.md
@@ -93,7 +93,7 @@ sponsor:
     sponsors:
     - thoughtworks
     - equal-experts
-  - title: "Meetup Sponsor"
+  - title: "Meetup & Hacknight Sponsor"
     size: "m"
     sponsors:
     - walmartlabs


### PR DESCRIPTION
Renamed WalmartLabs as Meetup & Hacknight Sponsor



**Event title:**

**Organizer's name:**

cc @hasgeek/events-review
