### PR TITLE
`x` button closes instructor modal - Fixes #255

### DIFF
--- a/_includes/instructors_section.html
+++ b/_includes/instructors_section.html
@@ -51,7 +51,7 @@
           </div>
         </div>
       </div>
-      <button class="modal-close is-large" onclick="hideModal('sponsor-{{ sponsor_type.title | slugify }}-{{ sponsor.title | slugify }}')"></button>
+      <button class="modal-close is-large" onclick="hideModal('instructor-{{ instructor.name | slugify }}')"></button>
     </div>
   </div>
   {% endfor %}


### PR DESCRIPTION
Closes instructor modal when clicking the `x` button
