### PR TITLE
Lock version of Cerberus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ruamel.yaml
 behave
-cerberus
+cerberus==1.1


### PR DESCRIPTION
Lock the version of Cerberus to 1.1 since 1.2 has an open issue with custom rules

https://github.com/pyeve/cerberus/issues/379

cc @akshaybhalotia 
