### PR TITLE
Fixed json formatting by using smartify and whitespace control

### DIFF
--- a/api/all.json
+++ b/api/all.json
@@ -1,16 +1,16 @@
 ---
 ---
-{% assign conferences = site.data.conferences | sort: 'start_time' %}
-{% assign events = site.data.events | sort: 'start_time' %}
-{% assign cities = site.data.cities %}
+{%- assign conferences = site.data.conferences | sort: 'start_time' -%}
+{%- assign events = site.data.events | sort: 'start_time' -%}
+{%- assign cities = site.data.cities -%}
 
-{% capture now_date %}{{ site.time | date: '%s' | plus: 0 }}{% endcapture %}
+{%- capture now_date -%}{{ site.time | date: '%s' | plus: 0 }}{%- endcapture -%}
 
 {
 	"conferences": [
-		{% for conf in conferences %}
-		{% capture conf_end_date %}{{conf.end_time | date: '%s' | plus: 0 }}{% endcapture %}
-		{% if conf_end_date > now_date %}
+		{%- for conf in conferences -%}
+		{%- capture conf_end_date -%}{{conf.end_time | date: '%s' | plus: 0 }}{%- endcapture -%}
+		{%- if conf_end_date > now_date -%}
 			{
 				"id": "{{ conf.name }}",
 				"title": "{{ conf.title }}",
@@ -21,17 +21,16 @@
 				"end_time": "{{ conf.end_time | date_to_xmlschema }}",
 				"url": "{{ conf.url }}",
 				"funnel": "{{ conf.funnel }}",
-				"blurb": "{{ conf.blurb }}"
+				"blurb": "{{ conf.blurb | smartify }}"
 				{% if conf.color %}, "color": {{conf.color|jsonify}} {% endif %}
 			}{% if forloop.last == false %},{% endif %}
-		{% else %}
-		{% endif %}
-		{% endfor %}
+		{%- endif -%}
+		{%- endfor -%}
 	],
 	"events": [
-		{% for event in events %}
-		{% capture event_end_date %}{{event.end_time | date: '%s' | plus: 0 }}{% endcapture %}
-		{% if event_end_date > now_date %}
+		{%- for event in events -%}
+		{%- capture event_end_date -%}{{event.end_time | date: '%s' | plus: 0 }}{%- endcapture -%}
+		{%- if event_end_date > now_date -%}
 			{
 				"name": "{{ event.name }}",
 				"title": "{{ event.title }}",
@@ -42,17 +41,16 @@
 				"end_time": "{{ event.end_time | date_to_xmlschema }}",
 				"url": "{{ event.url }}",
 				"funnel": "{{ event.funnel }}",
-				"blurb": "{{ event.blurb }}"
+				"blurb": "{{ event.blurb | smartify }}"
 			}
-			{% if forloop.last == false %},{% endif %}
-		{% else %}
-		{% endif %}
-		{% endfor %}
+			{%- if forloop.last == false -%},{%- endif -%}
+		{%- endif -%}
+		{%- endfor -%}
 	],
 	"cities": [
-		{% for city in cities %}
+		{%- for city in cities -%}
 		"{{ city }}"
-		{% if forloop.last == false %},{% endif %}
-		{% endfor %}
+		{%- if forloop.last == false -%},{%- endif -%}
+		{%- endfor -%}
 	]
 }

--- a/api/conferences.json
+++ b/api/conferences.json
@@ -1,13 +1,13 @@
 ---
 ---
-{% assign conferences = site.data.conferences | sort: 'start_time' %}
-{% capture now_date %}{{ site.time | date: '%s' | plus: 0 }}{% endcapture %}
+{%- assign conferences = site.data.conferences | sort: 'start_time' -%}
+{%- capture now_date -%}{{ site.time | date: '%s' | plus: 0 }}{%- endcapture -%}
 
 {
   "conferences": [
-	{% for conf in conferences %}
-  {% capture conf_end_date %}{{conf.end_time | date: '%s' | plus: 0 }}{% endcapture %}
-  {% if conf_end_date > now_date %}
+	{%- for conf in conferences -%}
+  {%- capture conf_end_date -%}{{conf.end_time | date: '%s' | plus: 0 }}{%- endcapture -%}
+  {%- if conf_end_date > now_date -%}
 		{
 			"id": "{{ conf.name }}",
 			"title": "{{ conf.title }}",
@@ -19,11 +19,10 @@
 			"url": "{{ conf.url }}",
 			"funnel": "{{ conf.funnel }}",
 			"blurb": "{{ conf.blurb }}"
-			{% if conf.color %}, "color": {{conf.color|jsonify}} {% endif %}
+			{%- if conf.color -%}, "color": {{conf.color|jsonify}} {%- endif -%}
 		}
 		{% if forloop.last == false %},{% endif %}
-  {% else %}
-  {% endif %}
-	{% endfor %}
+  {%- endif -%}
+	{%- endfor -%}
 	]
 }

--- a/api/events.json
+++ b/api/events.json
@@ -1,13 +1,13 @@
 ---
 ---
-{% assign events = site.data.events | sort: 'start_time' %}
-{% capture now_date %}{{ site.time | date: '%s' | plus: 0 }}{% endcapture %}
+{%- assign events = site.data.events | sort: 'start_time' -%}
+{%- capture now_date -%}{{ site.time | date: '%s' | plus: 0 }}{%- endcapture -%}
 
 {
   "events": [
-	{% for event in events %}
-  {% capture event_end_date %}{{event.end_time | date: '%s' | plus: 0 }}{% endcapture %}
-  {% if event_end_date > now_date %}
+	{%- for event in events -%}
+  {%- capture event_end_date -%}{{event.end_time | date: '%s' | plus: 0 }}{%- endcapture -%}
+  {%- if event_end_date > now_date -%}
 		{
 			"name": "{{ event.name }}",
 			"title": "{{ event.title }}",
@@ -18,11 +18,10 @@
 			"end_time": "{{ event.end_time | date_to_xmlschema }}",
 			"url": "{{ event.url }}",
 			"funnel": "{{ event.funnel }}",
-			"blurb": "{{ event.blurb }}"
+			"blurb": "{{ event.blurb | smartify }}"
 		}
 		{% if forloop.last == false %},{% endif %}
-  {% else %}
-  {% endif %}
-	{% endfor %}
+  {%- endif -%}
+	{%- endfor -%}
 	]
 }


### PR DESCRIPTION
The events JSON api was broken because there was a quote added to an event's blurb and the templates could not handle that. this fixes that using [`smartify`](https://jekyllrb.com/docs/templates/).

Also, the generated JSONs had massive amount of blank lines, fixed those using [whitespace control](https://shopify.github.io/liquid/basics/whitespace/).
