### PR TITLE
adding featured image in mobile

### DIFF
--- a/_includes/featured_event_card.html
+++ b/_includes/featured_event_card.html
@@ -66,7 +66,7 @@
       <p class="is-size-1">{{ include.event.description | truncate: 400, "..." | markdownify }}</p>
     </div>
   </div>
-  <div class="column auto is-hidden-mobile">
+  <div class="column auto featured-image">
     <img src="{{ include.event.featured_image }}" >
   </div>
 </div>

--- a/_includes/featured_event_card.html
+++ b/_includes/featured_event_card.html
@@ -66,8 +66,8 @@
       <p class="is-size-1">{{ include.event.description | truncate: 400, "..." | markdownify }}</p>
     </div>
   </div>
-  <div class="column auto">
-    <img src="{{ include.event.featured_image }}">
+  <div class="column auto is-hidden-mobile">
+    <img src="{{ include.event.featured_image }}" >
   </div>
 </div>
   </div>

--- a/_sass/bulma_material_overrides.scss
+++ b/_sass/bulma_material_overrides.scss
@@ -451,9 +451,14 @@ a{
 }
 
 .featured{
+    height: auto !important;
    p{
         font-size: 20px;
     }
+}
+
+.featured-image{
+  padding-bottom: 32px;
 }
 
 .no-padding{


### PR DESCRIPTION

**Event title:**

**Organizer's name:**

cc @hasgeek/events-review

No flashy GIF on mobile screens. 
<img width="142" alt="screen shot 2018-06-07 at 4 17 33 pm" src="https://user-images.githubusercontent.com/6479009/41095191-531f276c-6a6e-11e8-8ea9-e7b046aa43f9.png">
