### PR TITLE
Updated ffi to version 1.9.25 to fix build errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GEM
     execjs (2.7.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.21)
     ffi (1.9.21-x64-mingw32)
+    ffi (1.9.25)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (177)
@@ -243,7 +243,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.4.3p205
+   ruby 2.3.7p456
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
@jace @iambibhas Need a review on this. Noticed that builds were failing on travis and the ffi package seems to be the one causing issues.


https://travis-ci.org/hasgeek/events/builds/448779172